### PR TITLE
Add relativeTo query parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Angular templatecache webpack loader
 
+> This repo adds the 
+
 Puts HTML files to Angular $templateCache.
 
 
@@ -46,7 +48,20 @@ index.html
   }
 ```
 
-3. You can also use context in webpack to pass correct template url. See [Context example](https://github.com/EJIqpEP/angular-templatecache-loader/tree/master/examples/context)
+3. relativeTo - remove a string from the path
+
+relativeTo is used to strip a matching prefix from the path of the input html file.
+
+```javascript
+  {
+    test: /\.html$/,
+    loader: "angular-templatecache-loader?relativeTo=/public/"
+  }
+```
+
+The above will remove the "/public/" from the generated templateUrl path
+
+4. You can also use context in webpack to pass correct template url. See [Context example](https://github.com/EJIqpEP/angular-templatecache-loader/tree/master/examples/context)
 
 ```javascript
 var app = path.join(__dirname, 'app');

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ relativeTo is used to strip a matching prefix from the path of the input html fi
   }
 ```
 
-The above will remove the "/public/" from the generated templateUrl path
+The above will remove the "/public/" from the generated templateUrl path.
 
 4. You can also use context in webpack to pass correct template url. See [Context example](https://github.com/EJIqpEP/angular-templatecache-loader/tree/master/examples/context)
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = function (source) {
   var outputPath;
   var outputSource = '';
 
+  var relativeTo = query.relativeTo || '';
   var prefix = query.prefix || '';
   var module = query.module ? query.module : 'ng';
 
@@ -25,9 +26,9 @@ module.exports = function (source) {
   root = root.replace(/\\/g, separator);
 
   if (prefix) {
-    outputPath = prefix + resourcePath.replace(root, '');
+    outputPath = prefix + resourcePath.replace(root, '').replace(relativeTo, '');
   } else {
-    outputPath = resourcePath.replace(root, '').slice(1);
+    outputPath = resourcePath.replace(root, '').slice(1).replace(relativeTo, '');
   }
 
   this.cacheable && this.cacheable();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-templatecache-loader-2",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Webpack angular templateCache loader",
   "main": "index.js",
   "scripts": {
@@ -14,9 +14,9 @@
     "loader"
   ],
   "author": {
-    "name": "Alexander Kochergin",
-    "email": "ejiqpep@gmail.com",
-    "url": "https://github.com/EJIqpEP"
+    "name": "Paul Bastowski",
+    "email": "pbastowski@gmail.com",
+    "url": "https://github.com/pbastowski"
   },
   "license": "MIT",
   "devDependencies": {
@@ -33,10 +33,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/EJIqpEP/angular-templatecache-webpack-loader"
+    "url": "https://github.com/pbastowski/angular-templatecache-webpack-loader"
   },
   "bugs": {
-    "url": "https://github.com/EJIqpEP/angular-templatecache-webpack-loader/issues"
+    "url": "https://github.com/pbastowski/angular-templatecache-webpack-loader/issues"
   },
-  "homepage": "https://github.com/EJIqpEP/angular-templatecache-webpack-loader"
+  "homepage": "https://github.com/pbastowski/angular-templatecache-webpack-loader"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-templatecache-loader-2",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Webpack angular templateCache loader",
   "main": "index.js",
   "scripts": {
@@ -33,10 +33,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/pbastowski/angular-templatecache-webpack-loader"
+    "url": "https://github.com/pbastowski/angular-templatecache-loader"
   },
   "bugs": {
-    "url": "https://github.com/pbastowski/angular-templatecache-webpack-loader/issues"
+    "url": "https://github.com/pbastowski/angular-templatecache-loader/issues"
   },
-  "homepage": "https://github.com/pbastowski/angular-templatecache-webpack-loader"
+  "homepage": "https://github.com/pbastowski/angular-templatecache-loader"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "angular-templatecache-loader",
-  "version": "0.2.0",
+  "name": "angular-templatecache-loader-2",
+  "version": "0.3.0",
   "description": "Webpack angular templateCache loader",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-templatecache-loader-2",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Webpack angular templateCache loader",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-templatecache-loader-2",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Webpack angular templateCache loader",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
relativeTo is used to strip a matching prefix from the absolute path of the input html file. So, this works opposite to prefix.
